### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/MandatoryRCS/MandatoryRCS.version
+++ b/GameData/MandatoryRCS/MandatoryRCS.version
@@ -1,6 +1,6 @@
 {
   "NAME":"MandatoryRCS",
-  "URL":"https://forum.kerbalspaceprogram.com/index.php?/topic/154658-122-mandatoryrcs-12-1801-reaction-wheels-nerf-sas-rotation-persistence/",
+  "URL":"https://github.com/gotmachine/MandatoryRCS/raw/master/GameData/MandatoryRCS/MandatoryRCS.version",
   "DOWNLOAD":"https://github.com/gotmachine/MandatoryRCS/releases",
   "GITHUB":
   {


### PR DESCRIPTION
The URL property is supposed to point to an online copy of the version file that can be checked for updates, but currently it's the forum thread.
Now it's fixed.

- http://ksp.cybutek.net/kspavc/Documents/README.htm

Tagging @gotmachine because GitHub often doesn't send notifications for pull requests otherwise.

https://github.com/DasSkelett/AVC-VersionFileValidator by @DasSkelett can help with catching version file issues.





